### PR TITLE
Fix compilation when LIBAVFORMAT_VERSION_MICRO==100

### DIFF
--- a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.h
+++ b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.h
@@ -36,7 +36,7 @@ extern "C" {
     #include <libswscale/swscale.h>
 
 // Due to the whole ffmpeg / libAV silliness, we have to support libavresample on some platforms
-#if LIBAVFORMAT_VERSION_MICRO > 100
+#if LIBAVFORMAT_VERSION_MICRO >= 100
     #include <libswresample/swresample.h>
 #else
     #include <libavresample/avresample.h>


### PR DESCRIPTION
Since UBFFmpegVideoEncoder.cpp uses `avresample.h` for `LIBAVFORMAT_VERSION_MICRO<100` we have to be complementary here in the include file when including `swresample.h`.